### PR TITLE
apt update before install sudo

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -5,6 +5,7 @@
   apt: 
     name: sudo
     state: present
+    update_cache: yes
 
 ## Dealing with groups
 


### PR DESCRIPTION
If mirrors changes packages, `apt update` is needed. If don't, you'll may have a 404 - not found error.